### PR TITLE
added ignore option to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Available `options`:
   metadataEquals: (srcMetadata, dstMetadata) => { ... }
   batch: false,
   entries: null // Array of key entries (if you use this then prefix is ignored)
+  ignore: String || Array // Ignore source files and folders by name.
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = class MirrorDrive {
     this.bytesRemoved = 0
     this.bytesAdded = 0
     this.iterator = this._mirror()
-    this._ignore = opts.ignore
+    this._ignore = opts.ignore ? [].concat(opts.ignore) : null
   }
 
   [Symbol.asyncIterator] () {

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = class MirrorDrive {
     this.bytesRemoved = 0
     this.bytesAdded = 0
     this.iterator = this._mirror()
+    this._ignore = opts.ignore
   }
 
   [Symbol.asyncIterator] () {
@@ -95,7 +96,7 @@ module.exports = class MirrorDrive {
   }
 
   async * _list (a, b, opts) {
-    const list = this.entries || a.list(this.prefix)
+    const list = this.entries || a.list(this.prefix, { ignore: this._ignore })
 
     for await (const entry of list) {
       const key = typeof entry === 'object' ? entry.key : entry

--- a/test/basic.js
+++ b/test/basic.js
@@ -134,3 +134,20 @@ test('mirror with entries option', async function (t) {
   t.is(m2.bytesAdded, 8)
   t.alike(sortObjects(actual2), sortObjects(expected2))
 })
+
+test('mirror localdrive into hyperdrive with ignores', async function (t) {
+  const { local } = await createDrives(t)
+  const { hyper } = await createDrives(t, null, { setup: false })
+
+  await local.put('/folder/file.txt', b4a.from('same'))
+  await local.put('/folder/subfolder/file.txt', b4a.from('same'))
+
+  const m = new MirrorDrive(local, hyper, { ignore: ['/equal.txt', 'tmp.txt', '/folder/subfolder'] })
+  await m.done()
+
+  t.is(await hyper.get('/equal.txt'), null)
+  t.is(await hyper.get('/tmp.txt'), null)
+  t.is(await hyper.get('/folder/subfolder/file.txt'), null)
+
+  t.not(await hyper.get('/folder/file.txt'), null)
+})


### PR DESCRIPTION
This pr adds `ignore` to the mirror-drive constructor options and passes it to the mirror source list.

Example: `MirrorDrive(local, drive, { ignore: ['/a.txt', 'b.txt', '/folder/subfolder'] })`